### PR TITLE
Add more apparent link to the rules

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,3 +7,7 @@ title: Welcome to the Java Chatroom!
 # Come chat with us!
 
 Come join us on [Stack Overflow chat]({{site.url}})
+
+# Rules
+
+You can find the rules [here](/rules.html)


### PR DESCRIPTION
The only way to get to the rules was from a direct link or to see the rightmost link in the header bar. This link might help to get more people to read the rules if they find their way to the site.